### PR TITLE
fix: upgrade actions/checkout to v6 for Node.js 24 compatibility

### DIFF
--- a/.github/workflows/sync-project-status.yml
+++ b/.github/workflows/sync-project-status.yml
@@ -19,7 +19,7 @@ jobs:
   sync-status:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Sync status across projects
         env:


### PR DESCRIPTION
## Summary

- Upgrades `actions/checkout` from v4 to v6 in `sync-project-status.yml` to address GitHub's deprecation of Node.js 20 on Actions runners (hard deadline: June 2nd, 2026)

Resolves #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)