### PR TITLE
fix: use 'ready' label to detect issues ready for action

### DIFF
--- a/.github/workflows/auto-assign-actions.yml
+++ b/.github/workflows/auto-assign-actions.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   assign:
     if: |
-      contains(github.event.issue.labels.*.name, 'action') &&
+      contains(github.event.issue.labels.*.name, 'ready') &&
       github.event.issue.assignees[0] == null
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
## Summary
- Updates `auto-assign-actions.yml` to check for the `ready` label instead of `action`
- Aligns the workflow trigger with the new label convention where `ready` indicates an issue is ready for action

## Test plan
- [ ] Add `ready` label to an unassigned issue → workflow should auto-assign the reporter
- [ ] Verify `action` label no longer triggers auto-assignment

🤖 Generated with [Claude Code](https://claude.com/claude-code)