### PR TITLE
fix(workflows): remove duplicate schedule and add concurrency guards

### DIFF
--- a/.github/workflows/refresh-dashboard.yml
+++ b/.github/workflows/refresh-dashboard.yml
@@ -13,6 +13,10 @@ on:
     - cron: '0 5 * * *'
   workflow_dispatch:
 
+concurrency:
+  group: refresh-dashboard
+  cancel-in-progress: false
+
 jobs:
   sync-global:
     name: Sync Global Project

--- a/.github/workflows/sync-global-project.yml
+++ b/.github/workflows/sync-global-project.yml
@@ -4,14 +4,16 @@ name: Sync Global Project
 # Issues not yet in the project are added with Status = Inbox.
 # Issues already in the project with no Status are also set to Inbox.
 #
-# Runs daily at 05:00 UTC (1 hour before the dashboard update at 06:00).
-# Can also be triggered manually or called by refresh-dashboard.yml.
+# Triggered manually or called by refresh-dashboard.yml (daily at 05:00 UTC).
+# No standalone schedule — refresh-dashboard.yml is the single daily orchestrator.
 
 on:
-  schedule:
-    - cron: '0 5 * * *'
   workflow_dispatch:
   workflow_call:
+
+concurrency:
+  group: sync-global-project
+  cancel-in-progress: false
 
 jobs:
   sync:

--- a/.github/workflows/sync-project-status.yml
+++ b/.github/workflows/sync-project-status.yml
@@ -16,6 +16,10 @@ on:
   workflow_dispatch:
   workflow_call:
 
+concurrency:
+  group: sync-project-status
+  cancel-in-progress: true
+
 jobs:
   sync-status:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

- Removes the standalone `cron: '0 5 * * *'` from `sync-global-project.yml` — `refresh-dashboard.yml` already calls it as a reusable workflow on the same schedule, causing the sync script to run twice concurrently every day
- Adds `concurrency` group to `refresh-dashboard.yml` (`cancel-in-progress: false`) to prevent overlapping daily pipeline runs
- Adds `concurrency` group to `sync-project-status.yml` (`cancel-in-progress: true`) so a stuck 5-minute run is cancelled when the next fires instead of stacking

## What was happening

Both workflows shared the same cron trigger (`0 5 * * *`). Since `refresh-dashboard.yml` calls `sync-global-project.yml` as a reusable workflow, the sync script ran twice simultaneously every morning. Two concurrent instances competed for the 5000 points/hr GraphQL rate limit, exhausted it, and both hung before failing at the exact same second — taking the entire dashboard pipeline down with them.

## Test plan

- [ ] Trigger **Actions → Refresh Dashboard → Run workflow** manually and confirm only one `Sync Global Project` run appears — not two
- [ ] Confirm `sync-global-project.yml` no longer appears in the scheduled runs list at 05:00 UTC after merge
- [ ] Trigger **Refresh Dashboard** twice in quick succession and confirm the second run waits rather than running concurrently
- [ ] Let `sync-project-status.yml` run on its 5-minute schedule and confirm a new run cancels any still-running previous instance

Closes #28

🤖 Generated with [Claude Code](https://claude.com/claude-code)